### PR TITLE
Search fix due to wrong type hinting

### DIFF
--- a/app/code/local/Magentix/Solr/Model/Search.php
+++ b/app/code/local/Magentix/Solr/Model/Search.php
@@ -41,7 +41,7 @@ class Magentix_Solr_Model_Search extends Apache_Solr_Service
     /**
      * Represents a Solr response.
      *
-     * @var Apache_Solr_Response
+     * @var stdClass
      */
     protected $_response;
     
@@ -122,9 +122,9 @@ class Magentix_Solr_Model_Search extends Apache_Solr_Service
     /**
      * Set Solr response
      * 
-     * @param Apache_Solr_Response $response
+     * @param stdClass $response
      */
-    public function setResponse(Apache_Solr_Response $response)
+    public function setResponse($response)
     {
         $this->_response = $response;
     }


### PR DESCRIPTION
In the `Magentix_Solr_Model_Search::loadQuery()` method the `$response` returned by `$this->search()` is an instance of `Apache_Solr_Response` but then the response is taken from the `response` parsed data (by doing `$response->response`) which is an instance of `stdClass` and not `Apache_Solr_Response`. So the type hinting on `Magentix_Solr_Model_Search::setResponse()` was wrong.